### PR TITLE
Updates and fixes SettingsPage dark mode bug

### DIFF
--- a/build-vite/src/pages/SettingsPage.tsx
+++ b/build-vite/src/pages/SettingsPage.tsx
@@ -4,22 +4,22 @@ import { useAuth } from '../App';
 import { Logo } from '../components/Logo';
 
 type SettingsTab = 'profile' | 'security' | 'accessibility' | 'documents';
-type Theme = 'light' | 'dark';
 
 export default function SettingsPage() {
   const navigate = useNavigate();
   const location = useLocation();
   const { user, fontSize, setFontSize } = useAuth();
+  const [selectedTheme, setSelectedTheme] = useState<'light' | 'dark' >('light');
   const { logout } = useAuth();
 
-  // Check if we should open a specific tab from navigation state
+  // Active tab from navigation state or default
   const initialTab = (location.state as { tab?: SettingsTab })?.tab || 'profile';
   const [activeTab, setActiveTab] = useState<SettingsTab>(initialTab);
 
   // Profile state
-  const [displayName, setDisplayName] = useState(user?.name || ''); // need to change later
-  const [firstName, setFirstName] = useState(user?.name || ''); // need to change later
-  const [lastName, setLastName] = useState(user?.name || ''); // need to change later
+  const [displayName, setDisplayName] = useState(user?.name || '');
+  const [firstName, setFirstName] = useState(user?.name || '');
+  const [lastName, setLastName] = useState(user?.name || '');
   const [miscDetails, setMiscDetails] = useState('');
 
   // Security state
@@ -31,34 +31,20 @@ export default function SettingsPage() {
   const [newEmail, setNewEmail] = useState('');
   const [recoveryEmail, setRecoveryEmail] = useState('');
 
-  // Theme state (persistent)
-  const [theme, setTheme] = useState<Theme>(() => {
-    return (localStorage.getItem('theme') as Theme) || 'light';
-  });
-
-  useEffect(() => {
-    if (theme === 'dark') {
-      document.documentElement.classList.add('dark');
-    } else {
-      document.documentElement.classList.remove('dark');
-    }
-    localStorage.setItem('theme', theme);
-  }, [theme]);
-
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white transition-colors duration-300 pt-5">
+    <div className="min-h-screen bg-gray-50 text-gray-900 transition-colors duration-300 pt-5">
 
       {/* Header */}
-      <header className="bg-white dark:bg-gray-800 rounded-full px-6 py-4 flex items-center justify-between mx-5 shadow-lg">
+      <header className="bg-white rounded-full px-6 py-4 flex items-center justify-between mx-5 shadow-lg">
         <div className="flex items-center gap-4">
           <Logo size="medium" />
-          <h1 className="text-3xl text-blue-900 dark:text-gray-200">User Settings</h1>
+          <h1 className="text-3xl text-blue-900">User Settings</h1>
         </div>
         <nav className="flex items-center gap-8">
-          <button onClick={() => navigate('/dashboard')} className="hover:underline text-blue-800 dark:text-blue-300">Home</button>
-          <button onClick={() => navigate('/career-center')} className="hover:underline text-green-700 dark:text-green-400">Career Center</button>
-          <button onClick={() => navigate('/degree-center')} className="hover:underline text-blue-800 dark:text-blue-300">Degree Center</button>
-          <button onClick={logout} className="hover:underline text-red-600 dark:text-red-400">Log Out</button>
+          <button onClick={() => navigate('/dashboard')} className="hover:underline text-blue-800">Home</button>
+          <button onClick={() => navigate('/career-center')} className="hover:underline text-green-700">Career Center</button>
+          <button onClick={() => navigate('/degree-center')} className="hover:underline text-blue-800">Degree Center</button>
+          <button onClick={logout} className="hover:underline text-red-600">Log Out</button>
         </nav>
       </header>
 
@@ -66,34 +52,23 @@ export default function SettingsPage() {
 
         {/* Left Sidebar */}
         <div className="w-full lg:w-64">
-          <div className="bg-white dark:bg-gray-800 rounded-3xl p-6 space-y-4 shadow-lg">
-            <button
-              onClick={() => setActiveTab('profile')}
-              className={`w-full text-left px-6 py-3 rounded-full transition-colors ${activeTab === 'profile' ? 'bg-blue-700 text-white' : 'hover:bg-blue-50 dark:hover:bg-gray-700 text-gray-800 dark:text-gray-200'}`}
-            >
-              Profile
-            </button>
-            <button
-              onClick={() => setActiveTab('security')}
-              className={`w-full text-left px-6 py-3 rounded-full transition-colors ${activeTab === 'security' ? 'bg-blue-700 text-white' : 'hover:bg-blue-50 dark:hover:bg-gray-700 text-gray-800 dark:text-gray-200'}`}
-            >
-              Security
-            </button>
-            <button
-              onClick={() => setActiveTab('accessibility')}
-              className={`w-full text-left px-6 py-3 rounded-full transition-colors ${activeTab === 'accessibility' ? 'bg-blue-700 text-white' : 'hover:bg-blue-50 dark:hover:bg-gray-700 text-gray-800 dark:text-gray-200'}`}
-            >
-              Accessibility
-            </button>
-            <button
-              onClick={() => setActiveTab('documents')}
-              className={`w-full text-left px-6 py-3 rounded-full transition-colors ${activeTab === 'documents' ? 'bg-blue-700 text-white' : 'hover:bg-blue-50 dark:hover:bg-gray-700 text-gray-800 dark:text-gray-200'}`}
-            >
-              View Your Documents
-            </button>
+          <div className="bg-white rounded-3xl p-6 space-y-4 shadow-lg">
+            {['profile', 'security', 'accessibility', 'documents'].map((tab) => (
+              <button
+                key={tab}
+                onClick={() => setActiveTab(tab as SettingsTab)}
+                className={`w-full text-left px-6 py-3 rounded-full transition-colors ${
+                  activeTab === tab
+                    ? 'bg-blue-700 text-white'
+                    : 'hover:bg-blue-50 text-gray-800'
+                }`}
+              >
+                {tab === 'documents' ? 'View Your Documents' : tab.charAt(0).toUpperCase() + tab.slice(1)}
+              </button>
+            ))}
             <button
               onClick={logout}
-              className="w-full text-left px-6 py-3 rounded-full hover:bg-red-50 dark:hover:bg-red-700 text-red-600 dark:text-red-400 transition-colors"
+              className="w-full text-left px-6 py-3 rounded-full hover:bg-red-50 text-red-600 transition-colors"
             >
               Log Out
             </button>
@@ -101,51 +76,50 @@ export default function SettingsPage() {
         </div>
 
         {/* Main Content */}
-        <div className="flex-1 bg-white dark:bg-gray-800 rounded-3xl p-12 shadow-lg space-y-10">
+        <div className="flex-1 bg-white rounded-3xl p-12 shadow-lg space-y-10">
 
           {/* ---------------- PROFILE TAB ---------------- */}
           {activeTab === 'profile' && (
             <div className="space-y-8 max-w-2xl">
-
               <h2 className="text-4xl font-semibold border-b pb-4">Profile</h2>
 
               <div>
-                <label className="block text-2xl mb-2 text-gray-800 dark:text-gray-200">Display Name</label>
+                <label className="block text-2xl mb-2 text-gray-800">Display Name</label>
                 <input
                   type="text"
                   value={displayName}
                   onChange={(e) => setDisplayName(e.target.value)}
-                  className="w-full bg-white dark:bg-gray-700 border-2 border-blue-700 dark:border-blue-400 rounded-full px-6 py-3 outline-none focus:ring-2 focus:ring-blue-500"
+                  className="w-full bg-white border-2 border-blue-700 rounded-full px-6 py-3 outline-none focus:ring-2 focus:ring-blue-500"
                 />
               </div>
 
               <div>
-                <label className="block text-2xl mb-2 text-gray-800 dark:text-gray-200">Name</label>
+                <label className="block text-2xl mb-2 text-gray-800">Name</label>
                 <div className="grid grid-cols-2 gap-4">
                   <input
                     type="text"
                     value={firstName}
                     onChange={(e) => setFirstName(e.target.value)}
                     placeholder="First Name"
-                    className="bg-white dark:bg-gray-700 border-2 border-blue-700 dark:border-blue-400 rounded-full px-6 py-3 outline-none focus:ring-2 focus:ring-blue-500"
+                    className="bg-white border-2 border-blue-700 rounded-full px-6 py-3 outline-none focus:ring-2 focus:ring-blue-500"
                   />
                   <input
                     type="text"
                     value={lastName}
                     onChange={(e) => setLastName(e.target.value)}
                     placeholder="Last Name"
-                    className="bg-white dark:bg-gray-700 border-2 border-blue-700 dark:border-blue-400 rounded-full px-6 py-3 outline-none focus:ring-2 focus:ring-blue-500"
+                    className="bg-white border-2 border-blue-700 rounded-full px-6 py-3 outline-none focus:ring-2 focus:ring-blue-500"
                   />
                 </div>
               </div>
 
               <div>
-                <label className="block text-2xl mb-2 text-gray-800 dark:text-gray-200">Miscellaneous Details</label>
+                <label className="block text-2xl mb-2 text-gray-800">Miscellaneous Details</label>
                 <textarea
                   value={miscDetails}
                   onChange={(e) => setMiscDetails(e.target.value)}
                   placeholder="Tentative details..."
-                  className="w-full bg-white dark:bg-gray-700 border-2 border-blue-700 dark:border-blue-400 rounded-2xl px-6 py-3 outline-none focus:ring-2 focus:ring-blue-500 resize-none h-24"
+                  className="w-full bg-white border-2 border-blue-700 rounded-2xl px-6 py-3 outline-none focus:ring-2 focus:ring-blue-500 resize-none h-24"
                 />
               </div>
 
@@ -155,14 +129,12 @@ export default function SettingsPage() {
               >
                 Save Profile
               </button>
-
             </div>
           )}
 
           {/* ---------------- SECURITY TAB ---------------- */}
           {activeTab === 'security' && (
             <div className="space-y-10 max-w-2xl">
-
               <h2 className="text-4xl font-semibold border-b pb-4">Security</h2>
 
               {/* Change Password */}
@@ -181,21 +153,21 @@ export default function SettingsPage() {
                       placeholder="Current Password"
                       value={currentPassword}
                       onChange={(e) => setCurrentPassword(e.target.value)}
-                      className="w-full border-2 border-blue-700 dark:border-blue-400 rounded-full px-6 py-3 outline-none focus:ring-2 focus:ring-blue-500"
+                      className="w-full border-2 border-blue-700 rounded-full px-6 py-3 outline-none focus:ring-2 focus:ring-blue-500"
                     />
                     <input
                       type="password"
                       placeholder="New Password"
                       value={newPassword}
                       onChange={(e) => setNewPassword(e.target.value)}
-                      className="w-full border-2 border-blue-700 dark:border-blue-400 rounded-full px-6 py-3 outline-none focus:ring-2 focus:ring-blue-500"
+                      className="w-full border-2 border-blue-700 rounded-full px-6 py-3 outline-none focus:ring-2 focus:ring-blue-500"
                     />
                     <input
                       type="password"
                       placeholder="Confirm New Password"
                       value={confirmPassword}
                       onChange={(e) => setConfirmPassword(e.target.value)}
-                      className="w-full border-2 border-blue-700 dark:border-blue-400 rounded-full px-6 py-3 outline-none focus:ring-2 focus:ring-blue-500"
+                      className="w-full border-2 border-blue-700 rounded-full px-6 py-3 outline-none focus:ring-2 focus:ring-blue-500"
                     />
                     <button
                       onClick={() => {
@@ -233,14 +205,14 @@ export default function SettingsPage() {
                       placeholder="New Email"
                       value={newEmail}
                       onChange={(e) => setNewEmail(e.target.value)}
-                      className="w-full border-2 border-blue-700 dark:border-blue-400 rounded-full px-6 py-3 outline-none focus:ring-2 focus:ring-blue-500"
+                      className="w-full border-2 border-blue-700 rounded-full px-6 py-3 outline-none focus:ring-2 focus:ring-blue-500"
                     />
                     <input
                       type="email"
                       placeholder="Recovery Email (Optional)"
                       value={recoveryEmail}
                       onChange={(e) => setRecoveryEmail(e.target.value)}
-                      className="w-full border-2 border-blue-700 dark:border-blue-400 rounded-full px-6 py-3 outline-none focus:ring-2 focus:ring-blue-500"
+                      className="w-full border-2 border-blue-700 rounded-full px-6 py-3 outline-none focus:ring-2 focus:ring-blue-500"
                     />
                     <button
                       onClick={() => {
@@ -257,7 +229,6 @@ export default function SettingsPage() {
                 )}
               </div>
 
-              {/* Delete Account */}
               <div>
                 <button
                   className="w-full bg-red-600 hover:bg-red-700 text-white rounded-full px-6 py-3 transition"
@@ -265,89 +236,80 @@ export default function SettingsPage() {
                   Delete Account
                 </button>
               </div>
-
             </div>
           )}
 
-          {/* ---------------- ACCESSIBILITY TAB ---------------- */}
-          {activeTab === 'accessibility' && (
-            <div className="space-y-10 max-w-2xl">
+        {/* ---------------- ACCESSIBILITY TAB ---------------- */}
+        {activeTab === 'accessibility' && (
+          <div className="space-y-10 max-w-2xl">
+            <h2 className="text-4xl font-semibold border-b pb-4">Accessibility</h2>
 
-              <h2 className="text-4xl font-semibold border-b pb-4">Accessibility</h2>
-
-              {/* Theme */}
-              <div>
-                <h3 className="text-2xl mb-4">Theme</h3>
+            {/* Theme (clickable but non-functional) */}
+            <div>
+              <h3 className="text-2xl mb-4">Theme</h3>
                 <div className="flex gap-4">
                   <button
-                    onClick={() => setTheme('light')}
+                    onClick={() => setSelectedTheme('light')} // only updates visual selection
                     className={`px-8 py-3 rounded-full transition ${
-                      theme === 'light'
-                        ? 'bg-blue-700 text-white'
-                        : 'border-2 border-blue-700 text-blue-700 dark:border-blue-300 dark:text-blue-300'
+                      selectedTheme === 'light'
+                        ? 'bg-blue-700 text-white' // highlighted when selected
+                        : 'bg-gray-200 text-gray-800 border-2 border-gray-400' // unselected look
                     }`}
                   >
                     Light Mode
                   </button>
                   <button
-                    onClick={() => setTheme('dark')}
+                    onClick={() => setSelectedTheme('dark')} // only updates visual selection
                     className={`px-8 py-3 rounded-full transition ${
-                      theme === 'dark'
-                        ? 'bg-gray-900 text-white'
-                        : 'bg-gray-200 text-gray-800 dark:bg-gray-800 dark:text-gray-200'
+                      selectedTheme === 'dark'
+                        ? 'bg-blue-700 text-white' // highlighted when selected
+                        : 'bg-gray-200 text-gray-800 border-2 border-gray-400' // unselected look
                     }`}
                   >
                     Dark Mode
                   </button>
                 </div>
-              </div>
-
-              {/* Text Size */}
-              <div>
-                <h3 className="text-2xl mb-4">Text Size</h3>
-                <div className="flex gap-4">
-                  <button
-                    onClick={() => setFontSize('small')}
-                    className={`px-8 py-3 rounded-full transition ${
-                      fontSize === 'small'
-                        ? 'bg-green-600 text-white'
-                        : 'bg-white dark:bg-gray-700 border-2 border-green-600 text-green-600 hover:bg-green-50 dark:hover:bg-gray-600'
-                    }`}
-                  >
-                    Smaller Font
-                  </button>
-                  <button
-                    onClick={() => setFontSize('large')}
-                    className={`px-8 py-3 rounded-full transition ${
-                      fontSize === 'large'
-                        ? 'bg-green-600 text-white'
-                        : 'bg-white dark:bg-gray-700 border-2 border-green-600 text-green-600 hover:bg-green-50 dark:hover:bg-gray-600'
-                    }`}
-                  >
-                    Bigger Font
-                  </button>
-                </div>
-              </div>
-
             </div>
-          )}
+
+            {/* Text Size */}
+            <div>
+              <h3 className="text-2xl mb-4">Text Size</h3>
+              <div className="flex gap-4">
+                <button
+                  onClick={() => setFontSize('small')}
+                  className={`px-8 py-3 rounded-full transition ${
+                    fontSize === 'small'
+                      ? 'bg-green-600 text-white'
+                      : 'bg-white border-2 border-green-600 text-green-600 hover:bg-green-50'
+                  }`}
+                >
+                  Smaller Font
+                </button>
+                <button
+                  onClick={() => setFontSize('large')}
+                  className={`px-8 py-3 rounded-full transition ${
+                    fontSize === 'large'
+                      ? 'bg-green-600 text-white'
+                      : 'bg-white border-2 border-green-600 text-green-600 hover:bg-green-50'
+                  }`}
+                >
+                  Bigger Font
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
 
           {/* ---------------- DOCUMENTS TAB ---------------- */}
           {activeTab === 'documents' && (
             <div className="space-y-10 max-w-2xl">
-
               <h2 className="text-4xl font-semibold border-b pb-4">Documents</h2>
-
-              {/* No Documents Message */}
               <div className="text-center py-12">
-                <p className="text-2xl text-gray-500 dark:text-gray-400 mb-6">No documents</p>
-                <button
-                  className="bg-blue-700 hover:bg-blue-800 text-white rounded-full px-8 py-3 transition"
-                >
+                <p className="text-2xl text-gray-500 mb-6">No documents</p>
+                <button className="bg-blue-700 hover:bg-blue-800 text-white rounded-full px-8 py-3 transition">
                   Add Documents
                 </button>
               </div>
-
             </div>
           )}
 


### PR DESCRIPTION
## Summary

Fixes a previously attempted dark-mode feature by disabling dark mode, but keeping the buttons for future addition. The settings page only was stuck in dark mode, so now the settings page (like all other pages) are in light mode.

## Issue Link

N/A

## Root Cause Analysis

A failed and poorly planned attempt at implementing dark-mode feature

## Changes

Edits the settings page to remove dark mode framework that only applied to that page.

## Impact

This fix should only have UI improvements to the settings page and be unaffiliated with any other page.

## Testing Strategy

Tested using vite-build local hosting

## Regression Risk

Very minimal, as no other page is affected by this change.

## Checklist

- [ ] The fix has been locally tested

- [ ] New unit tests have been added to prevent future regressions

- [ ] The documentation has been updated if necessary

## Additional Notes