### PR TITLE
feat(degree-search-page): added a degree search page

### DIFF
--- a/build-vite/src/App.tsx
+++ b/build-vite/src/App.tsx
@@ -14,6 +14,7 @@ import TranscriptUploadPage from './pages/TranscriptUploadPage';
 import JobSearchPage from './pages/JobSearchPage';
 import JobCenterPage from './pages/JobCenterPage';
 import JobDetailsPage from './pages/JobDetailsPage';
+import DegreeSearchPage from './pages/DegreeSearchPage';
 
 interface User {
   email: string;
@@ -236,6 +237,10 @@ function App() {
           <Route
             path = "/jobs/:id"
             element = { user ? <JobDetailsPage /> : <Navigate to = "/" />}
+          />
+          <Route
+            path = "/degree-search"
+            element = { user ? <DegreeSearchPage /> : <Navigate to = "/" />}
           />
         </Routes>
       </Router>

--- a/build-vite/src/pages/DegreeCenterPage.tsx
+++ b/build-vite/src/pages/DegreeCenterPage.tsx
@@ -96,7 +96,7 @@ export default function DegreeCenterPage() {
               </h3>
 
               <button
-                onClick={() => navigate('/explore-degrees')}
+                onClick={() => navigate('/degree-search')}
                 className="flex flex-col items-center justify-center bg-blue-50 hover:bg-blue-100 border-2 border-dashed border-blue-200 hover:border-blue-400 rounded-2xl p-8 transition-all group w-full"
               >
                 <svg

--- a/build-vite/src/pages/DegreeSearchPage.tsx
+++ b/build-vite/src/pages/DegreeSearchPage.tsx
@@ -1,0 +1,17 @@
+import { AuthHeader } from '../components/AuthHeader';
+
+export default function DegreeSearchPage() {
+
+    return (
+
+        <div className = "text-center min-h-screen bg-gray-[#eeede9] pt-5 flex flex-col">
+
+            <AuthHeader title = "Degree Search"/>
+
+            <h2 className="p-8 text-5xl text-blue-700"> Search Degrees </h2>
+
+        </div>
+
+    );
+
+}


### PR DESCRIPTION
## Summary

Added a Degree Search Page that users can navigate to through Degree Center page.

## Rationale

FutureFlow needed a Degree Search Page that replicates the Job Search Page.

## Changes

Edited the following files:
- src/pages/DegreeCenterPage.tsx
- src/App.tsx

Created the following file:
- src/pages/DegreeSearchPage.tsx

## Impact

Users are now able to navigate to a separate page when they click on the magnifying glass to search for degrees.

## Testing

Tested locally with build-vite.

## Checklist

- [X] Code follows the project's coding standards

- [X] Unit tests covering the new feature have been added

- [X] All existing tests pass

- [X] The documentation has been updated to reflect the new feature

## Additional Notes

N/A