### PR TITLE
bug(about-us-header): fixed header in About Us page

### DIFF
--- a/build-vite/src/components/AboutUsHeader.tsx
+++ b/build-vite/src/components/AboutUsHeader.tsx
@@ -1,0 +1,83 @@
+import { useNavigate } from 'react-router-dom';
+import { useState, useEffect } from "react";
+import { Logo } from '../components/Logo';
+import { useAuth } from "../App";
+
+interface AuthHeaderProps {
+  title: string;
+}
+
+export function AboutUsHeader({ title }: AuthHeaderProps) {
+
+  const navigate = useNavigate();
+  const { loginWithCode } = useAuth();
+
+  // Handle Cognito redirect (?code=...)
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get("code");
+
+    if (code) {
+      loginWithCode(code).then(() => {
+        navigate("/dashboard");
+      });
+    }
+  }, [loginWithCode, navigate]);
+
+  // Redirect user to Cognito Hosted UI
+  const login = () => {
+    const clientId = "58koplp30bju3c58suq5505b8q";
+    const domain = "https://us-east-1j1ioyaxog.auth.us-east-1.amazoncognito.com";
+    const redirectUri = import.meta.env.VITE_APP_URL;
+    const scope = "email+openid+profile";
+
+    window.location.href =
+      `${domain}/login?client_id=${clientId}&response_type=code&scope=${scope}&redirect_uri=${redirectUri}`;
+  };
+
+  // testing a sticky header that transitions to a full bar when past a certain point
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    function handleScroll() {
+      setScrolled(window.scrollY > 60);
+    }
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  return (
+    <header
+      className={`sticky top-0 z-50 bg-white flex items-center justify-between shadow-lg transition-all duration-300 ${
+        scrolled
+          ? "rounded-none mx-0 px-10 py-4"       // full-width flat bar
+          : "rounded-full mx-5 px-6 py-4"   // floating pill
+      }`}
+    >
+      <div className="flex items-center gap-4">
+        <Logo size="medium" />
+        <h1 className="text-3xl font-semibold text-[#067c95]">{title}</h1>
+      </div>
+      <nav className="flex font-medium items-center gap-4">
+        {/* executive change to have tab appear permanently */}
+        
+        {/* Button to return to previous page */}
+        {/* works for both auth and non auth users */}
+        <nav className="flex items-center gap-4">
+          <button
+            onClick={() => navigate(-1)}
+            className="bg-gradient-to-r from-[#038eab] to-[#03b6be]
+                       hover:bg-blue-800 text-white px-6 py-3
+                       rounded-full
+                       shadow-lg hover:shadow-xl hover:shadow-[0_10px_30px_rgba(3,182,190,0.4)]
+                       transition-all duration-300
+                       focus:outline-none focus:ring-2 focus:ring[#03b6be] focus:ring-offset-2"
+          >
+            Go Back
+          </button>
+        </nav>
+
+      </nav>
+    </header>
+  );
+}

--- a/build-vite/src/components/NonAuthHeader.tsx
+++ b/build-vite/src/components/NonAuthHeader.tsx
@@ -1,14 +1,39 @@
-// import React from 'react';
-import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router';
-import { Logo } from './Logo';
+import { useNavigate } from 'react-router-dom';
+import { useState, useEffect } from "react";
+import { Logo } from '../components/Logo';
+import { useAuth } from "../App";
 
 interface AuthHeaderProps {
   title: string;
 }
 
 export function NonAuthHeader({ title }: AuthHeaderProps) {
+
   const navigate = useNavigate();
+  const { loginWithCode } = useAuth();
+
+  // Handle Cognito redirect (?code=...)
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get("code");
+
+    if (code) {
+      loginWithCode(code).then(() => {
+        navigate("/dashboard");
+      });
+    }
+  }, [loginWithCode, navigate]);
+
+  // Redirect user to Cognito Hosted UI
+  const login = () => {
+    const clientId = "58koplp30bju3c58suq5505b8q";
+    const domain = "https://us-east-1j1ioyaxog.auth.us-east-1.amazoncognito.com";
+    const redirectUri = import.meta.env.VITE_APP_URL;
+    const scope = "email+openid+profile";
+
+    window.location.href =
+      `${domain}/login?client_id=${clientId}&response_type=code&scope=${scope}&redirect_uri=${redirectUri}`;
+  };
 
   // testing a sticky header that transitions to a full bar when past a certain point
   const [scrolled, setScrolled] = useState(false);
@@ -26,25 +51,26 @@ export function NonAuthHeader({ title }: AuthHeaderProps) {
       className={`sticky top-0 z-50 bg-white flex items-center justify-between shadow-lg transition-all duration-300 ${
         scrolled
           ? "rounded-none mx-0 px-10 py-4"       // full-width flat bar
-          : "rounded-full mx-5 px-6 py-4 mt-5"   // floating pill
+          : "rounded-full mx-5 px-6 py-4"   // floating pill
       }`}
     >
       <div className="flex items-center gap-4">
         <Logo size="medium" />
-        <h1 className="text-3xl text-blue-900">{title}</h1>
+        <h1 className="text-3xl font-semibold text-[#067c95]">{title}</h1>
       </div>
-      <nav className="flex items-center gap-4">
+      <nav className="flex font-medium items-center gap-4">
+        {/* executive change to have tab appear permanently */}
+        
+        {/* About Us tab on the header */}
+        <button onClick={() => navigate('/about')} className="hover:underline text-[#067c95]">
+          ABOUT US
+        </button>
 
-        {/* Blue button to return to previous page */}
-        {/* works for both auth and non auth users */}
-        <nav className="flex items-center gap-4">
-          <button
-            onClick={() => navigate(-1)}
-            className="bg-blue-700 hover:bg-blue-800 text-white px-6 py-3 rounded-full transition-colors"
-          >
-            Go Back
-          </button>
-        </nav>
+        { /* Log-In / Sign-Up Header */ }
+        <button onClick = {login} className = "hover:underline text-[#067c95]">
+          LOGIN / SIGN-UP
+        </button>
+
       </nav>
     </header>
   );

--- a/build-vite/src/index.css
+++ b/build-vite/src/index.css
@@ -1,3 +1,59 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+
+.wave::before {
+  content: "";
+  position: absolute;
+  top: -10px;
+  width: 100%;
+  height: 20px;
+  background: rgba(0,0,0,0.1);
+  filter: blur(10px);
+}
+
+.wave {
+  position: absolute;
+  width: 300%;
+  height: 55%;
+  bottom: 0;
+  left: 0;
+  opacity: 0.8;
+
+  background: linear-gradient(
+    90deg,
+    #00cac5 0%,
+    #038eab 25%,
+    #03b6be 50%,
+    #038eab 75%,
+    #0584a4 100%
+  );
+  border-radius: 40% 60% 0 0;
+  animation: waveMove 8s linear infinite;
+  will-change: transform;
+}
+
+.wave2 {
+  bottom: 10px;
+  animation-duration: 15s;
+  opacity: 0.5;
+}
+
+.wave3 {
+  bottom: 20px;
+  animation-duration: 20s;
+  opacity: 0.3;
+}
+
+@keyframes waveMove {
+  0% {
+    transform: translateX(0) translateY(0);
+  }
+  50% {
+    transform: translateX(-25%) translateY(-8px);
+  }
+  100% {
+    transform: translateX(-50%) translateY(0);
+  }
+}

--- a/build-vite/src/pages/AboutPage.tsx
+++ b/build-vite/src/pages/AboutPage.tsx
@@ -1,10 +1,10 @@
 // import React from 'react';
-import { NonAuthHeader } from '../components/NonAuthHeader';
+import { AboutUsHeader } from "../components/AboutUsHeader";
 
 export default function AboutPage() {
   return (
     <div className="min-h-screen bg-gray-50 pt-5">
-      <NonAuthHeader title="Future Flow"/>
+      <AboutUsHeader title="Future Flow"/>
 
 
   {/*

--- a/build-vite/src/pages/JobSearchPage.tsx
+++ b/build-vite/src/pages/JobSearchPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from 'react';
 import { useNavigate, useSearchParams, useLocation } from 'react-router-dom';
 import { AuthHeader } from '../components/AuthHeader';
-import { useJobs } from '../hooks/useJobs';
+//import { useJobs } from '../hooks/useJobs';
 
 const PAGE_SIZE = 5;
 

--- a/build-vite/src/pages/LandingPage.tsx
+++ b/build-vite/src/pages/LandingPage.tsx
@@ -1,7 +1,8 @@
 import { useNavigate } from 'react-router-dom';
 import { useEffect } from "react";
-import { Logo } from '../components/Logo';
 import { useAuth } from "../App";
+import { NonAuthHeader } from '../components/NonAuthHeader';
+import '../index.css';
 
 export default function LandingPage() {
   const navigate = useNavigate();
@@ -31,87 +32,95 @@ export default function LandingPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      {/* Hero Section */}
-      <div className="bg-blue-50 rounded-3xl mx-5 mt-5 px-8 py-6">
 
-        {/* Header */}
-        <header className="bg-white flex rounded-full mx-5 px-6 py-4 flex items-center justify-between mb-12 shadow-lg text-md">
-          <Logo size="medium" />
+    <div className="min-h-screen pt-5">
 
-          <p className="text-xl text-blue-800 flex gap-8 self-end mb-2">
-            {/* "Insert SHORT slogan right here!" */}
-          </p>
+      <NonAuthHeader title = "Homepage"/>
 
-          <nav className="flex gap-4">
-            <button
-              onClick={() => navigate('/about')}
-              className="hover:underline text-blue-800"
-            >
-              ABOUT US
-            </button>
+      <div style = {{ position: "relative", minHeight: "100vh", overflow: "hidden" }}>
 
-            <button
-              onClick={login}
-              className="hover:underline text-blue-800"
-            >
-              LOGIN / SIGN-UP
-            </button>
-          </nav>
-        </header>
+        { /* Wave Background */ }
+        <div className = "wave"></div>
+        <div className = "wave wave2"></div>
+        <div className = "wave wave3"></div>
+
+        <div style = {{ position: "relative", zIndex: 2 }}>
 
         {/* Hero Content */}
-        <div className="text-center py-12">
-          <h1 className="text-8xl mb-4 text-blue-900">FutureFlow</h1>
+        <div className="text-center py-24 sm:py-12 md:py-16">
+          <h1 className="text-[#00cac5] text:7xl sm:text-7xl md:text-8xl mb-2"> FutureFlow </h1>
+
+          <h2 className = "text-[#00cac5] text-xl sm:text-xl md:text-xl mb-10 mx-auto leading-relaxed">
+            Don't just ride the waves. Let your Future Flow.
+          </h2>
 
           <button
             onClick={login}
-            className="bg-blue-700 hover:bg-blue-800 text-white px-12 py-4 rounded-full text-lg transition-colors"
+            className="bg-gradient-to-r from-[#038eab] to-[#03b6be] mt-10
+                       text-white px-12 py-4 sm:px-12 sm:py-4 md:px-12
+                       rounded-full text-lg font-semibold text-base sm:text-lg tracking-wide
+                       shadow-lg hover:shadow-xl hover:shadow-[0_10px_30px_rgba(3,182,190,0.4)]
+                       transition-all duration-300
+                       hover:-translate-y-1 hover:scale-[1.02] active:scale-95
+                       focus:outline-none focus:ring-2 focus:ring-[#03b6be] focus:ring-offset-2"
           >
-            Get Started
+            Start Your Journey →
           </button>
         </div>
-      </div>
 
-      {/* Career and Degree Search Sections */}
-      <div className="grid grid-cols-2 gap-8 px-5 py-8">
+        {/* Career and Degree Search Sections */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 sm:gap-6 md:gap-12 sm:px-10 md:px-12 sm:py-16 md:py-20">
 
-        {/* Career Search */}
-        <div className="bg-white border-2 border-green-600 rounded-3xl p-12 shadow-lg">
-          <h2 className="text-5xl mb-4 text-green-700">Career Search</h2>
+        {/* Job Search */}
+        <div className="cursor-pointer bg-white/85 backdrop-blur-lg
+                        border border-white/20
+                        rounded-3xl p-12 sm:p-8 md:p-12
+                        shadow-md hover:shadow-[0_20px_50px_rgba(0,0,0,0.15)] hover:-translate-y-2 hover:scale-[1.02]
+                        transition-all duration-300
+                        flex flex-col items-center justify-between h-full
+                        active:scale-95"
+             onClick = {login}>
+          <h2 className="text-[#065F46] font-semibold text-4xl sm:text-4xl md:text-5xl mb-4 text-center">
+            Job Search
+          </h2>
 
-          <p className="text-lg mb-8 text-center text-gray-700">
-            "Small explanation/purpose of this box/list of bullet points."
+          <p className="text-base sm:text-lg mb-6 sm:mb-8 text-center text-gray-600 mt-4 leading-relaxed">
+            See opportunities, salaries, and real-world paths.
           </p>
 
           <div className="flex justify-center">
-            <button
-              onClick={login}
-              className="bg-green-600 hover:bg-green-700 text-white px-8 py-3 rounded-full transition-colors"
-            >
-              Explore Careers
-            </button>
+            <span className = "text-green-600 text-3xl">
+              Explore →
+            </span>
           </div>
         </div>
 
         {/* Degree Search */}
-        <div className="bg-white border-2 border-blue-700 rounded-3xl p-12 shadow-lg">
-          <h2 className="text-5xl mb-4 text-blue-800">Degree Search</h2>
+        <div className="cursor-pointer bg-white/85 backdrop-blur-lg
+                        border border-white/20
+                        rounded-3xl p-12 sm:p-8 md:p-12
+                        shadow-md hover:shadow-[0_20px_50px_rgba(0,0,0,0.15)] hover:-translate-y-2 hover:scale-[1.02]
+                        transition-all duration-300
+                        flex flex-col items-center justify-between h-full
+                        active:scale-95"
+              onClick = {login}>
+          <h2 className="text-[#1E3A8A] font-semibold text-4xl sm:text-4xl md:text-5xl mb-4 text-center">
+            Degree Search
+          </h2>
 
-          <p className="text-lg mb-8 text-center text-gray-700">
-            "Small explanation/purpose of this box/list of bullet points."
+          <p className="text-base sm:text-lg mb-6 sm:mb-8 text-center text-gray-600 mt-4 leading-relaxed">
+            Find programs that lead to real opportunities.
           </p>
 
           <div className="flex justify-center">
-            <button
-              onClick={login}
-              className="bg-blue-700 hover:bg-blue-800 text-white px-8 py-3 rounded-full transition-colors"
-            >
-              Explore Degrees
-            </button>
+            <span className = "text-blue-700 text-3xl">
+              Explore →
+            </span>
           </div>
         </div>
 
+          </div>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

About Us page header is now fixed to navigate to the last page traveled instead of being a standard "non-authorized" or "authorized" header.

## Issue Link

https://github.com/UNLV-CS472-672/2026-S-GROUP4-FutureFlow/issues/108

## Root Cause Analysis

It was identified by @oceguedadiego and @seantranUNLV . When the Landing Page was redesigned, and thus the Non-Auth header, it affected the About Us page.

## Changes

Created the following file:
- src/components/AboutUsHeader.tsx

Edited the following file:
- src/pages/AboutPage.tsx

## Impact

Users can now go back to the last navigated page from the About Us page.

## Testing Strategy

Tested locally with build-vite.

## Regression Risk

If this change does not work as intended, I can simply adjust the About Us header.

## Checklist

- [X] The fix has been locally tested

- [X] New unit tests have been added to prevent future regressions

- [X] The documentation has been updated if necessary

## Additional Notes

N/A
