### PR TITLE
bug : upload.api.ts fixed

### DIFF
--- a/build-vite/src/api/uploads.api.ts
+++ b/build-vite/src/api/uploads.api.ts
@@ -6,16 +6,19 @@
 /*
     type: Type
     var name: UploadResponse
+    description: The response object containing the pre-signed URL and the key for the uploaded file
+    - uploadUrl: string - the pre-signed URL for uploading the file to S3
+    - key: string - the key for the uploaded file in S3, used to access the file after upload
 */
 export type UploadResponse = {
     uploadUrl: string;
-    fileUrl: string;
+    key: string;
 };
 
 // get pre-signed URL
 async function getUploadUrl(file: File): Promise<UploadResponse> {
 
-    // calls for API Gateway URL
+    // calls for API Gateway URL of upload-resume / transcript
     const res = await fetch("https://api-url.amazonaws.con/EXAMPLE", {
         method: "POST",
         headers: {
@@ -54,11 +57,56 @@ async function uploadToS3( uploadUrl: string, file: File ): Promise<void> {
 
 }
 
+async function uploadResumeToDatabase( key: string ): Promise<void> {
+    const res = await fetch("https://api-url.amazonaws.com/EXAMPLE", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            fileKey: key,
+        }),
+    });
+
+    if (!res.ok) {
+        throw new Error("Failed to Upload to Database.");
+    }
+
+}
+async function uploadTranscriptToDatabase( key: string ): Promise<void> {
+    const res = await fetch("https://api-url.amazonaws.com/EXAMPLE", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            fileKey: key,
+        }),
+    });
+
+    if (!res.ok) {
+        throw new Error("Failed to Upload to Database.");
+    }
+
+}
+
+//Create two functions that will call the parsing lambdas. They will need to be looked up. Then, attach them into the 
+//upload functions below. 
+
 // what ResumeUploadPage && TranscriptUploadPage call
-export async function uploadPDF( file: File ): Promise<UploadResponse> {
+export async function uploadResume( file: File ): Promise<UploadResponse> {
 
     const data = await getUploadUrl(file);
     await uploadToS3(data.uploadUrl, file);
+    await uploadResumeToDatabase(data.key);
     return data;
 
+}
+
+export async function uploadTranscript( file: File ): Promise<UploadResponse> {
+
+    const data = await getUploadUrl(file);
+    await uploadToS3(data.uploadUrl, file);
+    await uploadTranscriptToDatabase(data.key);
+    return data;
 }

--- a/build-vite/src/api/uploads.api.ts
+++ b/build-vite/src/api/uploads.api.ts
@@ -1,3 +1,4 @@
+import { useAuth } from "../App";
 /* SOURCE CODE TYPESCRIPT FILE FOR HANDLING API UPLOADS FOR:
         - ResumeUploadPage.tsx
         - TranscriptUploadPage.tsx
@@ -10,19 +11,31 @@
     - uploadUrl: string - the pre-signed URL for uploading the file to S3
     - key: string - the key for the uploaded file in S3, used to access the file after upload
 */
+const { tokens } = useAuth();
+const token = tokens?.idToken; // Assuming you have the token available from your auth context
 export type UploadResponse = {
     uploadUrl: string;
     key: string;
 };
+const UPLOAD_FILE_API_URL = import.meta.env.VITE_UPLOAD_FILE
+const STORE_TRANSCRIPT_KEY_API_URL = import.meta.env.VITE_STORE_TRANSCRIPT_KEY
+const STORE_RESUME_KEY_API_URL = import.meta.env.VITE_STORE_RESUME_KEY
 
-// get pre-signed URL
+/*
+    type: Function
+    name: getUploadUrl
+    Description: This function takes a file and returns the uploadUrl and key
+    Input: file - the file to be uploaded
+    Output: Promise<UploadResponse> - a promise resolving to the upload response object
+*/
 async function getUploadUrl(file: File): Promise<UploadResponse> {
 
     // calls for API Gateway URL of upload-resume / transcript
-    const res = await fetch("https://api-url.amazonaws.con/EXAMPLE", {
+    const res = await fetch(UPLOAD_FILE_API_URL, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
+            "Authorization": `Bearer ${token}`,  // Lambda verifies this and extracts sub using the API Gateway
         },
         body: JSON.stringify({
             fileName: file.name,
@@ -30,17 +43,24 @@ async function getUploadUrl(file: File): Promise<UploadResponse> {
         }),
     });
 
-    // if HTTP request unsuccessful, throw an error
+    // If HTTP request unsuccessful, throw an error
     if (!res.ok) {
         throw new Error("Failed to Retrieve Upload URL.");
     }
 
-    // returns https urls as JavaScript objects
+    // Returns https urls as JavaScript objects
     return res.json();
 
 }
 
-// upload to S3
+/*
+    type: Function
+    name: uploadToS3
+    Description: This function uploads a file to S3 using the provided upload URL
+    Input: uploadUrl - the pre-signed URL for uploading the file to S3
+           file - the file to be uploaded
+    Output: Promise<void> - a promise resolving when the upload is complete
+*/
 async function uploadToS3( uploadUrl: string, file: File ): Promise<void> {
 
     const res = await fetch(uploadUrl, {
@@ -57,11 +77,19 @@ async function uploadToS3( uploadUrl: string, file: File ): Promise<void> {
 
 }
 
-async function uploadResumeToDatabase( key: string ): Promise<void> {
-    const res = await fetch("https://api-url.amazonaws.com/EXAMPLE", {
+/*
+    type: Function
+    name: uploadResumeToDatabase
+    Description: This function uploads the key of the uploaded resume to the database
+    Input: key - the key for the uploaded file in S3, used to access the file after upload
+    Output: Promise<void> - a promise resolving when the upload is complete
+*/
+async function uploadResumeToDatabase(key: string ): Promise<void> {
+    const res = await fetch(STORE_RESUME_KEY_API_URL, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
+            "Authorization": `Bearer ${token}`,  // Lambda verifies this and extracts sub using the API Gateway
         },
         body: JSON.stringify({
             fileKey: key,
@@ -73,11 +101,14 @@ async function uploadResumeToDatabase( key: string ): Promise<void> {
     }
 
 }
+
+// Same function as uploadResumeToDatabase but for transcripts instead of resumes.
 async function uploadTranscriptToDatabase( key: string ): Promise<void> {
-    const res = await fetch("https://api-url.amazonaws.com/EXAMPLE", {
+    const res = await fetch(STORE_TRANSCRIPT_KEY_API_URL, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
+            "Authorization": `Bearer ${token}`,  // Lambda verifies this and extracts sub using the API Gateway
         },
         body: JSON.stringify({
             fileKey: key,
@@ -93,7 +124,8 @@ async function uploadTranscriptToDatabase( key: string ): Promise<void> {
 //Create two functions that will call the parsing lambdas. They will need to be looked up. Then, attach them into the 
 //upload functions below. 
 
-// what ResumeUploadPage && TranscriptUploadPage call
+// Export functions that the frontend will call.
+// It consolidates the above functions into one. 
 export async function uploadResume( file: File ): Promise<UploadResponse> {
 
     const data = await getUploadUrl(file);


### PR DESCRIPTION
# Bug Fix PR Template

## Summary

Changed structure of the upload to match the current structure of frontend -> backend -> frontend (for upload link) -> backend(for key).

## Issue Link

The PR will be attached to the appropriate issues. 

## Root Cause Analysis

I noticed that it was following the old template of how we were going to pass the key back to the front end and to call another lambda function after wards. 

## Changes

Added a separate function uploadToResume and uploadToTranscript to differentiate the call and store to appropriate parameters in the database.

## Impact

The frontend page should not be heavily impacted but the functionality of where the uploading changes. 

## Testing Strategy

Tested on Lambda AWS

## Regression Risk

N/A

## Checklist

- [X] The fix has been locally tested

- [X] New unit tests have been added to prevent future regressions

- [X] The documentation has been updated if necessary

## Additional Notes

N/A